### PR TITLE
Add lock file path in setup-env

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: tardis-sn/tardis-actions/setup-env@dev
+      - uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: "linux-64"
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -111,7 +111,7 @@ jobs:
           user_name: "TARDIS Bot"
           user_email: "tardis.sn.bot@gmail.com"
       
-      - uses: tardis-sn/tardis-actions/setup-docs-comments@docs-actions
+      - uses: tardis-sn/tardis-actions/setup-docs-comments@main
         with:
           bot-token: ${{ secrets.BOT_TOKEN }}
           repository: ${{ github.repository }}

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -28,18 +28,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Download Lock File
+      - name: Prepare Lock File
         run: |
           if [ -n "${{ inputs.lockfile-path }}" ]; then
-            cp -f "${{ inputs.lockfile-path }}" conda-${{ inputs.os-label }}.lock
+            echo "lockfile=${{ inputs.lockfile-path }}" >> "${GITHUB_OUTPUT}"
           else
             wget -q ${{ inputs.lock-file-url-prefix }}/conda-${{ inputs.os-label }}.lock
+            echo "lockfile=conda-${{ inputs.os-label }}.lock" >> "${GITHUB_OUTPUT}"
           fi
+        id: lockfile-path
         shell: bash
       
       - name: Generate Cache Key
         run: | 
-          file_hash=$(cat conda-${{ inputs.os-label }}.lock | shasum -a 256 | cut -d' ' -f1)
+          file_hash=$(cat "${{ steps.lockfile-path.outputs.lockfile }}" | shasum -a 256 | cut -d' ' -f1)
           echo "file_hash=tardis-conda-env-${{ inputs.os-label }}-${file_hash}-v1" >> "${GITHUB_OUTPUT}"
         id: cache-environment-key
         shell: bash
@@ -47,7 +49,7 @@ runs:
       - name: Setup Micromamba and Cache
         uses: mamba-org/setup-micromamba@v2
         with:
-          environment-file: conda-${{ inputs.os-label }}.lock
+          environment-file: ${{ steps.lockfile-path.outputs.lockfile }}
           cache-environment-key: ${{ steps.cache-environment-key.outputs.file_hash }}
           cache-downloads-key: ${{ steps.cache-environment-key.outputs.file_hash }}
           environment-name: ${{ inputs.environment-name }}

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -31,7 +31,7 @@ runs:
       - name: Download Lock File
         run: |
           if [ -n "${{ inputs.lockfile-path }}" ]; then
-            cp "${{ inputs.lockfile-path }}" conda-${{ inputs.os-label }}.lock
+            cp -f "${{ inputs.lockfile-path }}" conda-${{ inputs.os-label }}.lock
           else
             wget -q ${{ inputs.lock-file-url-prefix }}/conda-${{ inputs.os-label }}.lock
           fi

--- a/setup-env/action.yml
+++ b/setup-env/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: "os label for lock file, default linux-64"
     required: true
     default: "linux-64"
+  lockfile-path:
+    description: "local path to lock file (takes precedence over lock-file-url-prefix)"
+    required: false
   lock-file-url-prefix:
     description: "url for lock file, default tardis-base/master"
     required: false
@@ -26,7 +29,12 @@ runs:
   using: "composite"
   steps:
       - name: Download Lock File
-        run:  wget -q ${{ inputs.lock-file-url-prefix }}/conda-${{ inputs.os-label }}.lock
+        run: |
+          if [ -n "${{ inputs.lockfile-path }}" ]; then
+            cp "${{ inputs.lockfile-path }}" conda-${{ inputs.os-label }}.lock
+          else
+            wget -q ${{ inputs.lock-file-url-prefix }}/conda-${{ inputs.os-label }}.lock
+          fi
         shell: bash
       
       - name: Generate Cache Key


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

- [X] Adds an option to provide the lock file from the path. This option takes precedence over the URL option. 
- [X] Tested in https://github.com/tardis-sn/tardis/pull/3269 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
