### PR TITLE
git-lfs-pull label fix

### DIFF
--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -118,21 +118,3 @@ jobs:
         with:
           path: ${{ steps.repo-info.outputs.name }}/.git/lfs
           key: tardis-regression-${{ inputs.atom-data-sparse == true && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles(format('{0}/.lfs-files-list', steps.repo-info.outputs.name)) }}-${{ inputs.regression-data-repo }}-v1
-
-      - name: Remove label
-        if: ${{ inputs.allow_lfs_pull }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                name: 'git-lfs-pull'
-              });
-              console.log('Successfully removed git-lfs-pull label');
-            } catch (error) {
-              console.log(`Unable to remove git-lfs-pull label: ${error.message}`);
-            }


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Removes the script that removed the label to save LFS 
https://github.com/tardis-sn/tardis/pull/3367
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
